### PR TITLE
Add staged option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Current Working Directory - this will tell the method, in which directory it sho
 ## groups [object]
 For each key defined in the groups, the lib will try to find matching files. The value for they hey should either be a *method* or a *regexp*.
 
+## staged [boolean]
+List only files staged for next commit
+
 ## Result
 It will be an object with list of files at the keys. For example I got the following, when ran the [above example](#example-usage) against this repo:
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,11 @@ function formatExtraGroups (groups) {
 module.exports = function gitFiles (options) {
   options = options || {};
 
-  var files = execSync('git ls-files', {
+  var cmd = options.staged ?
+    'git diff --diff-filter ACMR --cached --name-only' :
+    'git ls-files';
+
+  var files = execSync(cmd, {
     encoding: 'utf8',
     cwd: options && options.cwd
   })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -19,10 +19,13 @@ function setup () {
   exec('echo haha > some.test.js');
   exec('echo hoho > some.js');
   exec('git init');
+  exec('git config user.email foo@example.com');
+  exec('git config user.name "Gigiri Tikiri"');
   exec('git add .');
   exec('git commit --no-gpg-sign -am test');
   exec('echo bello > staged.txt');
   exec('git add .');
+  exec('echo foobar > baz.txt');
 }
 
 function teardown () {
@@ -110,5 +113,17 @@ describe('git-files', function () {
 
     expect(custom.nothingInHere).to.be.an('array');
     expect(custom.nothingInHere).to.have.lengthOf(0);
+  });
+});
+
+describe('git-staged-files', function () {
+  it('should list only files that are staged for the next commit', function () {
+    var custom = gitFiles({
+      cwd: TEMP_DIR,
+      staged: true,
+    });
+
+    expect(custom.all).to.not.have.members(['baz.txt']);
+    expect(custom.all).to.have.members(['staged.txt']);
   });
 });


### PR DESCRIPTION
If staged option true, it lists only those files which are staged for
the next commit.

Useful for example to lint only the changed files.