### PR TITLE
fix node 0.12 support with grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "coveralls": "3.0.0",
-    "grunt": "^1.0.1",
+    "grunt": "1.0.2",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-jscs": "^3.0.1",
     "grunt-mocha-istanbul": "5.0.2",


### PR DESCRIPTION
**fix node 0.12 support with grunt**
grunt@1.0.3 uses `grunt-legacy-log-utils` which uses ES6 features, this broke
the tests for node 0.12